### PR TITLE
Specify package for code coverage

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-bash <(curl -s https://codecov.io/bash)
+bash <(curl -s https://codecov.io/bash) -J '$package'

--- a/step.yml
+++ b/step.yml
@@ -25,3 +25,8 @@ inputs:
         Codecov.io repository upload token
       is_required: true
       is_expand: true
+  - package:
+    opts:
+      title: "Packages"
+      description: |
+        Specify packages to build coverage. Will append as option `-J`


### PR DESCRIPTION
Wanted to add the option to specify which target to gather coverage information about. When you have quite a few pods, this can take a significant amount of extra time if this parameter isn't include.

I'm not entirely sure how the yml options are read in the script, but from looking around on other steps, I _think_ this will work? 😄 

Thanks!
