### PR TITLE
Pass along any Codecov argument

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-bash <(curl -s https://codecov.io/bash)
+bash <(curl -s https://codecov.io/bash) ${codecov}

--- a/step.yml
+++ b/step.yml
@@ -28,3 +28,10 @@ inputs:
       description: |
         Codecov.io repository upload token
       is_required: true
+  - codecov: "--codecov"
+    opts:
+      title: Additional options for Codecov call
+      description: |-
+        Options added to the end of the Gradle call.
+        You can use multiple options, separated by a space
+        character. Example: `--codecov -F unittests -J '^Project'`

--- a/step.yml
+++ b/step.yml
@@ -32,6 +32,7 @@ inputs:
     opts:
       title: Additional options for Codecov call
       description: |-
-        Options added to the end of the Gradle call.
-        You can use multiple options, separated by a space
+        Options to pass along to the Codecov uploader.
+        You can use multiple options, separated by a space.
+        Review all options at https://github.com/codecov/codecov-bash
         character. Example: `--codecov -F unittests -J '^Project'`

--- a/step.yml
+++ b/step.yml
@@ -35,4 +35,4 @@ inputs:
         Options to pass along to the Codecov uploader.
         You can use multiple options, separated by a space.
         Review all options at https://github.com/codecov/codecov-bash
-        character. Example: `--codecov -F unittests -J '^Project'`
+        Example: `--codecov -F unittests -J '^Project'`


### PR DESCRIPTION
Goal is to have customers include any number of additional arguments listed here: https://github.com/codecov/codecov-bash/blob/4c9c68c8aadf658812518a2b9a72a9038ee32dff/codecov#L53-L108

Thanks!
