### PR TITLE
remove `--codecov` from other_options

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -35,4 +35,4 @@ inputs:
         Options to pass along to the Codecov uploader.
         You can use multiple options, separated by a space.
         Review all options at https://github.com/codecov/codecov-bash
-        Example: `--codecov -F unittests -J '^Project'`
+        Example: `-F unittests -J '^Project'`


### PR DESCRIPTION
other_options: `-J "Apple"` ->`bash <(curl -s https://codecov.io/bash) -Z -J "Apple"`
