### PR TITLE
-Z is included in every case

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -35,4 +35,4 @@ inputs:
         Options to pass along to the Codecov uploader.
         You can use multiple options, separated by a space.
         Review all options at https://github.com/codecov/codecov-bash
-        Example: `-F unittests -J '^Project'`
+        Example: `-J '^Project'`


### PR DESCRIPTION
No need to have that in the example, it's already included: https://github.com/bitrise-io/steps-codecov/blob/master/step.sh#L5